### PR TITLE
Set default page size to 500 and expose page size setting to all queries for multiple entries

### DIFF
--- a/neuvueclient/__init__.py
+++ b/neuvueclient/__init__.py
@@ -287,6 +287,7 @@ class NeuvueQueue:
         **kwargs
     ):
 
+        # Get page size if user set it, otherwise set to 500
         pageSize = kwargs.get("pageSize", 500)
 
         params = {
@@ -302,7 +303,6 @@ class NeuvueQueue:
                 self.url(datatype), headers=self._headers, params=params
             )
         )
-        print(res)
         try:
             self._raise_for_status(res)
         except Exception as e:


### PR DESCRIPTION
Here are the graphs, for the record

`return_metadata=False, return_states=False`

![times](https://user-images.githubusercontent.com/24723182/186523483-421b6e14-99d0-4af6-93fe-7ba8f13fadc5.png)

`convert_states_to_json=False`

![times_selectall](https://user-images.githubusercontent.com/24723182/186523508-d6ab69a2-3507-4b6b-a0c1-3f11386209b8.png)

