### PR TITLE
#397 Add parallelization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ backoff
 black
 mypy
 pylint
+joblib


### PR DESCRIPTION
Adds a kwarg to the client that lets the user parallelize large requests. It currently breaks sorting so it needs a bit more debugging. Creating this PR so we have documentation of the timing tests I did.

I averaged 5 trials together for each data point
x=number of workers
y=seconds
pageSize=1000
total number of rows returned=15229

Requests made against neuvue-queue
![image](https://user-images.githubusercontent.com/24723182/214893641-ea0a6ab8-9221-4a22-9dea-27e7b2d69d4a.png)

Requests made against beefier mongo Danny spun up
![image](https://user-images.githubusercontent.com/24723182/214894046-71a531b1-3cb3-4a72-94f9-da864d41498e.png)

Both changing the number of workers and getting a beefier mongo has a positive effect on time elapsed, but not a significant enough one for us to diagnose the scalability issues as completely solvable via parallelization on the client side.