### PR TITLE
Increase default page size

### DIFF
--- a/neuvueclient/__init__.py
+++ b/neuvueclient/__init__.py
@@ -290,7 +290,7 @@ class NeuvueQueue:
     ):
 
         # Get page size if user set it, otherwise set to 500
-        pageSize = kwargs.get("pageSize", 500)
+        pageSize = kwargs.get("pageSize", 15000)
 
         params = {
             "p": page,


### PR DESCRIPTION
15,000 looked like a good, safely low number based on my preliminary tests, but just in case, I do not recommend pushing this to prod until Monday! If the page size is too large, the queue will return a 502.