### PR TITLE
Add task provenance to metadata

### DIFF
--- a/neuvueclient/utils.py
+++ b/neuvueclient/utils.py
@@ -139,3 +139,21 @@ def get_from_state_server(url: str, json_state_server_token):
     
     # TODO: Make sure its JSON String
     return resp.text.strip()
+
+def create_new_provenance(task, copy=False):
+    if copy:
+        return [{"assignee": task["assignee"], "status": task["status"], "copiedBy": task["author"], "copiedAt": task["created"], "copiedFrom": task["_id"]}]
+    else:
+        return [{"assignee": task["assignee"], "status": task["status"], "createdBy": task["author"], "createdAt": task["created"]}]
+
+def update_provenance(task, author, kwargs):
+    if 'provenance' not in task['metadata']:
+        new_provenance = create_new_provenance(task)
+    else:
+        new_provenance = task['metadata']['provenance']
+    # Should always have changedBy and changedAt
+    new_provenance_entry = {"changedBy": author, "changedAt": date_to_ms()}
+    for key, value in kwargs.items():
+        new_provenance_entry[key] = value
+    new_provenance.append(new_provenance_entry)
+    return new_provenance


### PR DESCRIPTION
_Logic_
* No provenance is needed on task creation
* During first task patch of assignee or status, provenance is created. 
```
[{
    'assignee': 'original assignee',
    'status': 'original status',
    'createdBy': 'task author',
    'changedAt': 'creation time'
},
{
    'changedBy': 'patch author',
    'changedAt': 'current timestamp',
    'assignee': 'new assignee', (optional)
    'status': 'new status' (optional)
}]
```
* On subsequent task patches, entries of the second format are added.
* On task copy, copy provenance is created.
```
[{
    'assignee': 'assignee',
    'status': 'status',
    'copiedBy': 'author',
    'copiedAt': 'creation time',
    'copiedFrom': 'task id'
}]
```
_Test cases_
Please test the following:
* Creating a task includes no provenance
* Patching a task with no assignee or status kwarg does not create provenance
* Patching a task with assignee or status kwarg creates provenance
* Patching a task with metadata kwarg and assignee or status kwarg correctly edits the metadata kwarg to add provenance
* Patching a task with a provenance already created correctly updates the provenance
* Copying a task creates a provenance field
* Copying a task with metadata kwarg correctly edits the metadata kwarg to add provenance